### PR TITLE
Include modify_struct handling on Postgres side of test_data

### DIFF
--- a/Ora2Pg.pm
+++ b/Ora2Pg.pm
@@ -20148,6 +20148,7 @@ ORDER BY attnum};
 	my @dest_types = ();
 	while ( my @crow = $tmpsth->fetchrow())
 	{
+		next if (!$self->is_in_struct($tb, $crow[0]));
 		if ($crow[2] eq 'geometry')
 		{
 			if ($self->{is_mysql}) {


### PR DESCRIPTION
Denne PR gjelder Data validation. Når man bruker config `MODIFY_STRUCT` eller `EXCLUDE_COLUMNS` for å ekskludere kolonner, blir dette kun gjort på Oracle-siden. Denne PR gjør slik at dette også gjøres på Postgres-siden. 