### PR TITLE
Pin Perl to version 5.38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:slim
+FROM perl:5.38-slim
 
 ARG ORA2PG_VERSION=24.3
 


### PR DESCRIPTION
Getting File::Spec module erors with perl v5.40 and ora2pg, so pinning perl to v5.38